### PR TITLE
Adopt `ts-node-script`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "palletjack",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3299,9 +3299,9 @@
       "dev": true
     },
     "shebang-trim": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-trim/-/shebang-trim-1.0.0.tgz",
-      "integrity": "sha512-RWf5hVBCxxOqMfMSFKhdDyMdGTSDOQWQtVR61Z1hgDIGKC00HCXOeYGcXpU6+so3wUU16Ot+Pc8ydZciyzOJsw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shebang-trim/-/shebang-trim-1.1.0.tgz",
+      "integrity": "sha512-utgXtqcJEpon3a1JRybKBmIXSzD2SkjfaQ3VffP9n9nZAqxfNQ0uWTcJ7ajUQy8DaQW9vqc4lcIa7CV15gAPuA==",
       "dev": true,
       "requires": {
         "write-file-atomically": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "mocha": "^7.1.2",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.5",
-    "shebang-trim": "^1.0.0",
+    "shebang-trim": "^1.1.0",
     "tmp-promise": "^3.0.2",
     "ts-mocha": "^7.0.0",
     "ts-node": "^8.1.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env ts-node
+#!/usr/bin/env ts-node-script
 
 'use strict'
 


### PR DESCRIPTION
Adopt `ts-node-script`, which automatically uses the tsconfig relative to the script, to simplify development.