### PR TITLE
Fix extensionless imports

### DIFF
--- a/src/archive.ts
+++ b/src/archive.ts
@@ -1,8 +1,8 @@
 import * as pathLib from 'path'
 import { promises as fs } from 'fs'
 import del from 'del'
-import Manifest, { GlobResult, MatchResult } from './manifest'
-import { copyFile, cleanGitRepo } from './fs'
+import Manifest, { GlobResult, MatchResult } from './manifest.js'
+import { copyFile, cleanGitRepo } from './fs.js'
 
 interface ArchiveOptions {
   manifest: Manifest

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,8 +5,8 @@
 import { ArgumentParser } from 'argparse'
 import { promises as fs } from 'fs'
 import path from 'path'
-import Manifest, { MatchResult } from './manifest'
-import Archive from './archive'
+import Manifest, { MatchResult } from './manifest.js'
+import Archive from './archive.js'
 
 export default async function main(inArgs?: string[]): Promise<void> {
   const { description, version } = JSON.parse(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,12 +5,20 @@
 import { ArgumentParser } from 'argparse'
 import { promises as fs } from 'fs'
 import path from 'path'
+import { fileURLToPath } from 'url'
 import Manifest, { MatchResult } from './manifest.js'
 import Archive from './archive.js'
 
 export default async function main(inArgs?: string[]): Promise<void> {
   const { description, version } = JSON.parse(
-    await fs.readFile(path.join(__dirname, '..', 'package.json'), 'utf-8')
+    await fs.readFile(
+      path.join(
+        path.dirname(fileURLToPath(import.meta.url)),
+        '..',
+        'package.json'
+      ),
+      'utf-8'
+    )
   )
 
   // TODO Improve this interface using subcommands.
@@ -67,14 +75,12 @@ export default async function main(inArgs?: string[]): Promise<void> {
   }
 }
 
-if (require.main === module) {
-  ;(async (): Promise<void> => {
-    try {
-      await main()
-    } catch (e) {
-      // eslint-disable-next-line no-console
-      console.error(e)
-      process.exit(1)
-    }
-  })()
-}
+;(async (): Promise<void> => {
+  try {
+    await main()
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(e)
+    process.exit(1)
+  }
+})()

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import Manifest from './manifest'
-import Archive from './archive'
+import Manifest from './manifest.js'
+import Archive from './archive.js'
 
 export { Manifest, Archive }


### PR DESCRIPTION
Extensionless imports, `require`, and `__dirname` do not work in ESM.